### PR TITLE
Fix regex to parse endpoint in url with 2 letter country suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ if (!ENDPOINT) {
 // Try to infer the region if it is not provided as an argument.
 var REGION = argv.r;
 if (!REGION) {
-    var m = ENDPOINT.match(/\.([^.]+)\.es\.amazonaws\.com\.?$/);
+    var m = ENDPOINT.match(/\.([^.]+)\.es\.amazonaws\.com\.?(?=.*$)/);
     if (m) {
         REGION = m[1];
     } else {


### PR DESCRIPTION
I modfied the regex to exclude the match from the top level domain

I tested it out on https://regex101.com/ with the following input:
1. some-cluster-identifier.cn-northwest-1.es.amazonaws.com.cn
2. some-cluster-identifier.us-west-2.es.amazonaws.com

Earlier, the region in url 1. was not being parsed correctly